### PR TITLE
Add tests for skill loading

### DIFF
--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -59,7 +59,7 @@ jobs:
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install ovos-core[skills] pytest mock
-          pip install -r requirements.txt
+          pip install .
       - name: Test Skill
         run: |
           pytest test/test_skill.py

--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt install -y gcc libfann-dev swig libssl-dev portaudio19-dev git libpulse-dev
           pip install --upgrade pip
           pip install pytest mock git+https://github.com/NeonGeckoCom/NeonCore#egg=neon_core
-          pip install -r requirements.txt
+          pip install .
       - name: Test Skill
         run: |
           pytest test/test_skill.py

--- a/locale/en-us/digits.voc
+++ b/locale/en-us/digits.voc
@@ -1,5 +1,0 @@
-digits
-digit
-part
-numbers
-number

--- a/locale/en-us/last.voc
+++ b/locale/en-us/last.voc
@@ -1,2 +1,0 @@
-last
-final

--- a/locale/en-us/what.ssid.intent
+++ b/locale/en-us/what.ssid.intent
@@ -1,1 +1,0 @@
-what (network|ssid|wifi|wifi network) are you (on|using|connected to)

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -128,7 +128,7 @@ class TestSkillLoading(unittest.TestCase):
     messages = list()
 
     # Specify skill ID for testing (can be anything)
-    test_skill_id = 'ip_address.test'
+    test_skill_id = 'test_skill.test'
 
     # Specify valid languages to test
     supported_languages = ["en-us"]

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -191,6 +191,9 @@ class TestSkillLoading(unittest.TestCase):
         self.assertEqual(registered_padatious, self.padatious_intents)
         for lang in self.supported_languages:
             self.assertEqual(set(registered_vocab[lang].keys()), self.vocab)
+            for voc in self.vocab:
+                # Ensure every vocab file has at least one entry
+                self.assertGreater(len(registered_vocab[lang][voc]), 0)
 
     def test_skill_events(self):
         events = self.default_events + self.adapt_intents

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -148,7 +148,7 @@ class TestSkillLoading(unittest.TestCase):
     supported_languages = ["en-us"]
 
     # Specify skill intents as sets
-    adapt_intents = {f'{test_skill_id}:IPIntent'}
+    adapt_intents = {'IPIntent'}
     padatious_intents = set()
 
     # regex entities, not necessarily filenames
@@ -164,6 +164,10 @@ class TestSkillLoading(unittest.TestCase):
         cls.bus.on("message", cls._on_message)
         cls.skill.config_core["secondary_langs"] = cls.supported_languages
         cls.skill._startup(cls.bus, cls.test_skill_id)
+        cls.adapt_intents = {f'{cls.test_skill_id}:{intent}'
+                             for intent in cls.adapt_intents}
+        cls.padatious_intents = {f'{cls.test_skill_id}:{intent}'
+                                 for intent in cls.padatious_intents}
 
     @classmethod
     def _on_message(cls, message):

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -122,26 +122,10 @@ class TestSkillLoading(unittest.TestCase):
     Test skill loading, intent registration, and langauge support. Test cases
     are generic, only class variables should be modified per-skill.
     """
-    from skill_ip_address import IPSkill
+    # Static parameters
     bus = FakeBus()
-    skill = IPSkill()
     messages = list()
-
-    # Specify skill ID for testing (can be anything)
     test_skill_id = 'test_skill.test'
-
-    # Specify valid languages to test
-    supported_languages = ["en-us"]
-
-    # Specify skill intents
-    adapt_intents = {f'{test_skill_id}:IPIntent'}
-    padatious_intents = set()
-
-    # Specify skill resources
-    regex = set()
-    vocab = {"query", "ip", "public"}  # Lowercased .voc file basenames
-    dialog = {"dot", "no network connection", "my address is",
-              "my address on X is Y"}
     # Default Core Events
     default_events = ["mycroft.skill.enable_intent",
                       "mycroft.skill.disable_intent",
@@ -155,6 +139,25 @@ class TestSkillLoading(unittest.TestCase):
                       f"{test_skill_id}.activate",
                       f"{test_skill_id}.deactivate"
                       ]
+
+    # Import and initialize installed skill
+    from skill_ip_address import IPSkill
+    skill = IPSkill()
+
+    # Specify valid languages to test
+    supported_languages = ["en-us"]
+
+    # Specify skill intents as sets
+    adapt_intents = {f'{test_skill_id}:IPIntent'}
+    padatious_intents = set()
+
+    # regex entities, not necessarily filenames
+    regex = set()
+    # vocab is lowercase .voc file basenames
+    vocab = {"query", "ip", "public"}
+    # dialog is .dialog file basenames (case-sensitive)
+    dialog = {"dot", "no network connection", "my address is",
+              "my address on X is Y"}
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
Inspired by https://github.com/OpenVoiceOS/skill-ovos-wikipedia/blob/dev/test/unittests/test_skill.py

Implements tests for required vocab and dialog resources, intent registration, and event listeners. Vocab and dialog can be extended for multi-language support