### PR TITLE
Update OVOS dependencies to allow 0.x versions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -45,13 +45,13 @@ from ifaddr import get_adapters
 from lingua_franca import load_language
 from neon_utils.user_utils import get_user_prefs
 from requests import get
-from adapt.intent import IntentBuilder
 from neon_utils.skills.neon_skill import NeonSkill
 from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
 from ovos_bus_client.message import Message
 from ovos_workshop.decorators import intent_handler
+from ovos_workshop.intents import IntentBuilder
 from lingua_franca.format import pronounce_number
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests~=2.20
 ifaddr~=0.1
-neon-utils~=1.7
+# TODO: network patching dependency resolution
+neon-utils[network]~=1.8,>=1.11.1a3
 ovos-utils~=0.0,>=0.0.28
 ovos-bus-client~=0.0,>=0.0.5
 ovos-workshop~=0.0,>=0.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests~=2.20
 ifaddr~=0.1
 neon-utils~=1.7
-ovos-utils~=0.0, >=0.0.28
-ovos-bus-client~=0.0.5
-ovos-workshop~=0.0.12
+ovos-utils~=0.0,>=0.0.28
+ovos-bus-client~=0.0,>=0.0.5
+ovos-workshop~=0.0,>=0.0.12

--- a/skill.json
+++ b/skill.json
@@ -16,9 +16,9 @@
         "python": [
             "ifaddr~=0.1",
             "neon-utils~=1.7",
-            "ovos-bus-client~=0.0.5",
-            "ovos-utils~=0.0, >=0.0.28",
-            "ovos-workshop~=0.0.12",
+            "ovos-bus-client~=0.0,>=0.0.5",
+            "ovos-utils~=0.0,>=0.0.28",
+            "ovos-workshop~=0.0,>=0.0.12",
             "requests~=2.20"
         ],
         "system": {},

--- a/skill.json
+++ b/skill.json
@@ -15,7 +15,7 @@
     "requirements": {
         "python": [
             "ifaddr~=0.1",
-            "neon-utils~=1.7",
+            "neon-utils[network]~=1.8,>=1.11.1a3",
             "ovos-bus-client~=0.0,>=0.0.5",
             "ovos-utils~=0.0,>=0.0.28",
             "ovos-workshop~=0.0,>=0.0.12",


### PR DESCRIPTION
# Description
Update ovos-workshop dependency
Replace `adapt.intent` import with `ovos-workshop` wrapper

# Issues
https://github.com/NeonGeckoCom/NeonCore/pull/708

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->